### PR TITLE
feat(AP-3058)!: republish with preset that respects "!" flag

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Tag
         run: |
+          npm install --global conventional-changelog-conventionalcommits
           npx --yes -- lerna version --yes
 
       - name: Save commit SHA


### PR DESCRIPTION
changes the "changelogPreset" from "angular" to "conventionalcommits" so that the "!" flag that indicates major version bump is respected