### PR TITLE
feat(AP-3058): drop conventionalcommits preset, just follow angular …

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Tag
         run: |
-          npm install --global conventional-changelog-conventionalcommits
           npx --yes -- lerna version --yes
 
       - name: Save commit SHA

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,6 @@
     "version": {
       "allowBranch": "main",
       "conventionalCommits": true,
-      "changelogPreset": "conventionalcommits",
       "message": "chore(release): publish %v",
       "private": false
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@evolv/eslint-config": "^1.1.3",
         "@types/jest": "^29.0.1",
         "@types/node": "^18.7.16",
-        "conventional-changelog-conventionalcommits": "^6.1.0",
         "del-cli": "^5.0.0",
         "eslint": "8.22.0",
         "eslint-config-next": "^12.3.0",
@@ -11813,18 +11812,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
       "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
-      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
@@ -40230,15 +40217,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
       "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-      "dev": true,
-      "requires": {
-        "compare-func": "^2.0.0"
-      }
-    },
-    "conventional-changelog-conventionalcommits": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
-      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@evolv/eslint-config": "^1.1.3",
     "@types/jest": "^29.0.1",
     "@types/node": "^18.7.16",
-    "conventional-changelog-conventionalcommits": "^6.1.0",
     "del-cli": "^5.0.0",
     "eslint": "8.22.0",
     "eslint-config-next": "^12.3.0",


### PR DESCRIPTION
…conventions

the angular conventions for conventional-commits do not respect the "!" flag to indicate a major version bump. however, the following line can use be used to indicate such

BREAKING CHANGE: upgraded to react@18 and next@13